### PR TITLE
Update hydra, tiamat, dhcp/dns, add TalDos, update IP allocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo is intended to be our new documentation solution for the labs. It's ea
 
 ## Development 
 
-The COSI book is built with [mdbook](https://github.com/rust-lang/mdBook). Skim over the [User Guide](https://rust-lang.github.io/mdBook/) to get a jist for how the tool works. Particularly the explanation on [SUMMARY.md](https://rust-lang.github.io/mdBook/format/summary.html).
+The COSI book is built with [mdbook](https://github.com/rust-lang/mdBook). Skim over the [User Guide](https://rust-lang.github.io/mdBook/) to get a gist for how the tool works. Particularly the explanation on [SUMMARY.md](https://rust-lang.github.io/mdBook/format/summary.html).
 
 1. Install the [rust](https://rustup.rs/) programming language.
 2. After setting up rust run `cargo install mdbook --vers "^0.4"` to get the tool.

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,3 +1,8 @@
 [default.extend-words]
 NED = "NED"
 
+[default]
+extend-ignore-identifiers-re = [
+    # Ignore mirror hard disk names
+    "2RW103_ZL2*",
+]

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,7 @@
   	- [Eldwyn](./infrastructure/servers/eldwyn.md)
     - [Hydra](./infrastructure/servers/hydra.md)
     - [Talos](./infrastructure/servers/talos.md)
+    - [TalDos](./infrastructure/servers/taldos.md)
     - [Tiamat](./infrastructure/servers/tiamat.md)
     - [Ziltoid](./infrastructure/servers/ziltoid.md)
 

--- a/src/infrastructure/network/ip_allocations.md
+++ b/src/infrastructure/network/ip_allocations.md
@@ -4,7 +4,7 @@ All links on this page should point at the underlying physical (or virtual) _inf
 
 ## IP Address Listing for 128.153.144.1/24 subnet
 
-_updated: Sept 4 2022_
+_updated: Sep 25, 2023_
 
 | 128.153.144.# | Name |
 | :--- | :---

--- a/src/infrastructure/network/ip_allocations.md
+++ b/src/infrastructure/network/ip_allocations.md
@@ -34,12 +34,11 @@ _updated: Sep 25, 2023_
 | :--- | :---
 | 1 | OIT Gateway |
 | 2 | [Ziltoid](../servers/ziltoid.md) |
-| 3 | [Talos](../servers/talos.md) |
-| 4 | [Atlas](../vms.md#atlas) |
+| 3 | [TalDos](../servers/taldos.md) |
+| 4 | [Talos](../servers/talos.md) |
 | 42 | [Hydra](../servers/hydra.md) |
-| 53 | [Unbound](../vms.md#unbound) |
+| 53 | [TalDos](../servers/taldos.md) |
 | 179 | [hbox](../servers/hbox.md) |
-| 219 | [fsu](../vms.md#fsu) |
 
 
 ### Layout

--- a/src/infrastructure/network/ip_allocations.md
+++ b/src/infrastructure/network/ip_allocations.md
@@ -36,8 +36,11 @@ _updated: Sept 4 2022_
 | 2 | [Ziltoid](../servers/ziltoid.md) |
 | 3 | [Talos](../servers/talos.md) |
 | 4 | [Atlas](../vms.md#atlas) |
-| 179 | [hbox](../servers/hbox.md) |
+| 42 | [Hydra](../servers/hydra.md) |
 | 53 | [Unbound](../vms.md#unbound) |
+| 179 | [hbox](../servers/hbox.md) |
+| 219 | [fsu](../vms.md#fsu) |
+
 
 ### Layout
 

--- a/src/infrastructure/servers/hydra.md
+++ b/src/infrastructure/servers/hydra.md
@@ -1,6 +1,6 @@
 # Hydra
 
-_updated: Jan 31st 2023_
+_updated: Sep 25, 2023_
 
 Hydra is COSI's default VM host. 
 
@@ -14,10 +14,10 @@ Hydra is COSI's default VM host.
 
 | | |
 | :--- | :--- |
-| CPU | AMD Opteron 6376
-| RAM | ?
-| STORAGE | ? 
-| CONNECTIVITY | ?
+| CPU | AMD Opteron 6376 (x2)
+| RAM | 64 GB
+| STORAGE | 10TB (5x2TB)
+| CONNECTIVITY | 10Gbps
 
 ## Operating System
 
@@ -41,6 +41,7 @@ _updated: Sept 18th 2022_
 - [gitea](../vms.md#gitea)
 - [unbound](../vms.md#unbound)
 - [voip](../vms.md#voip)
+- [fsu](../vms.md#fsu)
 
 ## Notes
 

--- a/src/infrastructure/servers/hydra.md
+++ b/src/infrastructure/servers/hydra.md
@@ -41,7 +41,6 @@ _updated: Sept 18th 2022_
 - [gitea](../vms.md#gitea)
 - [unbound](../vms.md#unbound)
 - [voip](../vms.md#voip)
-- [fsu](../vms.md#fsu)
 
 ## Notes
 

--- a/src/infrastructure/servers/taldos.md
+++ b/src/infrastructure/servers/taldos.md
@@ -1,0 +1,38 @@
+# TalDos
+
+_updated: November 27, 2023_
+
+TalDos is COSI's primary DNS server, replacing Talos.
+
+| | |
+| :--- | :--- |
+| Location | [Server Room - Network 1](../racks.md#network-1) |
+| IP Addresses | 128.153.145.3, 128.153.145.53 |
+| Deployed | true |
+
+## Hardware
+
+| | |
+| :--- | :--- |
+| CPU | Intel Xeon E5620 (x2)
+| RAM | 12 GB
+| STORAGE | 300 GB
+| CONNECTIVITY | 1 Gbps
+
+## Operating System
+
+| | |
+| :--- | :--- |
+| OS | GNU/Linux
+| Distro | Debian 12 Bookworm
+| Last updated | Nov 2023
+| End of life | unknown
+| Enrolled in COSI auth | false
+| NFS Mount | false
+
+## Services
+
+[Authoritative DNS](../../services/authoritative_dns.md)
+[DHCP](../../services/dhcp.md)
+
+## Notes

--- a/src/infrastructure/servers/talos.md
+++ b/src/infrastructure/servers/talos.md
@@ -1,14 +1,15 @@
 # Talos
 
-_updated: September 30th, 2022_
+_updated: November 27th, 2023_
 
-Will be summuarized later
+Talos is COSI's old primary DNS server, and is currently planned to be set up
+in place of Atlas as our secondary DNS server.
 
 | | |
 | :--- | :--- |
 | Location | [Server Room - Network 3](../racks.md#network-3) |
-| IP Addresses | 128.153.145.3 |
-| Deployed | true |
+| IP Addresses | N/A |
+| Deployed | false |
 
 ## Hardware
 
@@ -40,3 +41,4 @@ Kerberos
 
 ## Notes
 
+Talos was replaced by TalDos in Fall 2023 after it crashed due to memory errors.

--- a/src/infrastructure/servers/talos.md
+++ b/src/infrastructure/servers/talos.md
@@ -8,7 +8,7 @@ in place of Atlas as our secondary DNS server.
 | | |
 | :--- | :--- |
 | Location | [Server Room - Network 3](../racks.md#network-3) |
-| IP Addresses | N/A |
+| IP Addresses | 128.153.145.4 |
 | Deployed | false |
 
 ## Hardware

--- a/src/infrastructure/servers/tiamat.md
+++ b/src/infrastructure/servers/tiamat.md
@@ -1,6 +1,10 @@
 # Tiamat
 
-_updated: September 27, 2022_
+_updated: November 27, 2023_
+
+Tiamat is COSI's web / container host, and is home to the CSlabs website, Talks, 
+Book, and others. Tiamat uses NGINX to proxy connections to each website and
+container.
 
 | | |
 | :--- | :--- |
@@ -12,10 +16,10 @@ _updated: September 27, 2022_
 
 | | |
 | :--- | :--- |
-| CPU |
-| RAM |
-| STORAGE |
-| CONNECTIVITY |
+| CPU | AMD Opteron 6220
+| RAM | 64 GB
+| STORAGE | 1TB
+| CONNECTIVITY | 10 Gbps
 
 ## Operating System
 
@@ -23,14 +27,22 @@ _updated: September 27, 2022_
 | :--- | :--- |
 | OS | GNU/Linux
 | Distro | Ubuntu 22.04
-| Last updated | September 27, 2022
+| Last updated | Nov 2023
 | End of life | April 2027
 | Enrolled in COSI auth | true
 | NFS Mount | false
 
 ## Services
 
-none
+Docker host
+
+## Websites
+
+[CSLabs](../../websites/cslabs.md)
+
+[Book](../../websites/book.md)
+
+[Talks](../../websites/talks.md)
 
 ## Notes
 

--- a/src/infrastructure/vms.md
+++ b/src/infrastructure/vms.md
@@ -1,6 +1,6 @@
 # Virtual Machines
 
-_updated: Sept 17th 2022_
+_updated: Sep 25, 2023_
 
 This chapter contains an alphabetically ordered list of all of COSI's virtual machines.
 
@@ -128,6 +128,28 @@ It is important that no two services use the same port.
 **Notes:**
 
 Everything running on dubsdot2 should be a [docker](https://www.docker.com) container using docker-compose. All of the containers are stored in `/opt`. Use the `readme` to keep track of port allocations and check other compose to learn how to let SSL be auto configured.
+
+## fsu
+
+_updated: Sept 25, 2023_
+
+fsu provides the Floating Soda Unit bank (Mount Fsuvius) for the labs.
+
+| | |
+| :--- | :--- |
+| Host | [hydra](./servers/hydra.md)
+| IP Addresses | 128.153.145.219
+| OS | GNU/Linux
+| Distro | Ubuntu 22.04 LTS
+| Last updated | ?
+| End of life | Apr 2027
+| Enrolled in COSI auth | false
+| NFS Mount | false
+
+**Services:**
+| Service | Port |
+| :--- | :--- |
+| [Mount Fsuvius](http://fsu.cslabs.clarkson.edu) | 80
 
 ## gitea
 

--- a/src/services/authoritative_dns.md
+++ b/src/services/authoritative_dns.md
@@ -21,13 +21,13 @@ When adding a new server to the network make sure you remember to add it's ip to
 
 ## NSD
 
-COSI has one authoritative DNS server running [NSD](https://en.wikipedia.org/wiki/NSD) which is `dns1.cosi.clarkson.edu` is running on [Talos](../infrastructure/servers/talos.md). 
+COSI has one authoritative DNS server running [NSD](https://en.wikipedia.org/wiki/NSD) which is `dns1.cosi.clarkson.edu` is running on [Taldos](../infrastructure/servers/taldos.md). 
 
 OIT's caching DNS servers are configured to cache the entire zone files over XFR. That is why we have XFR enabled for OIT's name servers. If you notice DNS results are buggy within the Clarkson network it is probably this.
 
 ## Webhook
 
-Deploying updates to the dns zones is a great use for Webhooks. Currently there is a webhook server built into the [zones](https://gitea.cosi.clarkson.edu/COSI_Maintainers/zones) repo.
+Deploying updates to the dns zones is a great use for Webhooks. Currently there is a webhook server built into the [zones](https://github.com/COSI-Lab/zones) repo.
 
 ## Current Configuration
 

--- a/src/services/dhcp.md
+++ b/src/services/dhcp.md
@@ -43,13 +43,13 @@ authoritative;
 
 # Use this to send dhcp log messages to a different log file (you also
 # have to hack syslog.conf to complete the redirection).
-#log-facility local7;
+# log-facility local7;
 
 # No service will be given on this subnet, but declaring it helps the 
 # DHCP server to understand the network topology.
 
-#subnet 10.152.187.0 netmask 255.255.255.0 {
-#}
+# subnet 10.152.187.0 netmask 255.255.255.0 {
+# }
 
 # This is a very basic subnet declaration.
 
@@ -80,7 +80,7 @@ subnet 128.153.144.0 netmask 255.255.254.0 {
 #}
 
 # Hosts which require special configuration options can be listed in
-# host statements.   If no address is specified, the address will be
+# host statements. If no address is specified, the address will be
 # allocated dynamically (if possible), but the host-specific information
 # will still come from the host declaration.
 
@@ -93,7 +93,7 @@ subnet 128.153.144.0 netmask 255.255.254.0 {
 # Fixed IP addresses can also be specified for hosts.   These addresses
 # should not also be listed as being available for dynamic assignment.
 # Hosts for which fixed IP addresses have been specified can boot using
-# BOOTP or DHCP.   Hosts for which no fixed address is specified can only
+# BOOTP or DHCP. Hosts for which no fixed address is specified can only
 # be booted with DHCP, unless there is an address range on the subnet
 # to which a BOOTP client is connected which has the dynamic-bootp flag
 # set.
@@ -103,7 +103,7 @@ subnet 128.153.144.0 netmask 255.255.254.0 {
 #}
 
 # You can declare a class of clients and then do address allocation
-# based on that.   The example below shows a case where all clients
+# based on that. The example below shows a case where all clients
 # in a certain class get addresses on the 10.17.224/24 subnet, and all
 # other clients get addresses on the 10.0.29/24 subnet.
 

--- a/src/services/dhcp.md
+++ b/src/services/dhcp.md
@@ -6,7 +6,10 @@ Since COSI has it's own network we also run a [DHCP](https://en.wikipedia.org/wi
 
 ## isc-dhcp-server
 
-The Internet Systems Consortium's implementation of a DHCP server is good enough. We have a single dhcp server running on [Talos](../infrastructure/servers/talos.md). In the past we had a fallback server running in a VM. This no longer exists.
+The Internet Systems Consortium's implementation of a DHCP server is good 
+enough. We have a single dhcp server running on 
+[TalDos](../infrastructure/servers/taldos.md). In the past we had a fallback
+server running in a VM. This no longer exists.
 
 ## DHCP information
 
@@ -20,6 +23,109 @@ The Internet Systems Consortium's implementation of a DHCP server is good enough
 
 ## Configuration 
 
-TODO
+```
+# option definitions common to all supported networks...
+option domain-name "cslabs.clarkson.edu";
+option domain-name-servers 1.1.1.1, 1.0.0.1;
 
+default-lease-time 600;
+max-lease-time 7200;
 
+# The ddns-updates-style parameter controls whether or not the server will
+# attempt to do a DNS update when a lease is confirmed. We default to the
+# behavior of the version 2 packages ('none', since DHCP v2 didn't
+# have support for DDNS.)
+ddns-update-style none;
+
+# If this DHCP server is the official DHCP server for the local
+# network, the authoritative directive should be uncommented.
+authoritative;
+
+# Use this to send dhcp log messages to a different log file (you also
+# have to hack syslog.conf to complete the redirection).
+#log-facility local7;
+
+# No service will be given on this subnet, but declaring it helps the 
+# DHCP server to understand the network topology.
+
+#subnet 10.152.187.0 netmask 255.255.255.0 {
+#}
+
+# This is a very basic subnet declaration.
+
+subnet 128.153.144.0 netmask 255.255.254.0 {
+  range 128.153.144.100 128.153.144.254;
+  option routers 128.153.144.1;
+  option ntp-servers 128.153.2.253, 128.153.5.253;
+}
+
+# This declaration allows BOOTP clients to get dynamic addresses,
+# which we don't really recommend.
+
+#subnet 10.254.239.32 netmask 255.255.255.224 {
+#  range dynamic-bootp 10.254.239.40 10.254.239.60;
+#  option broadcast-address 10.254.239.31;
+#  option routers rtr-239-32-1.example.org;
+#}
+
+# A slightly different configuration for an internal subnet.
+#subnet 10.5.5.0 netmask 255.255.255.224 {
+#  range 10.5.5.26 10.5.5.30;
+#  option domain-name-servers ns1.internal.example.org;
+#  option domain-name "internal.example.org";
+#  option routers 10.5.5.1;
+#  option broadcast-address 10.5.5.31;
+#  default-lease-time 600;
+#  max-lease-time 7200;
+#}
+
+# Hosts which require special configuration options can be listed in
+# host statements.   If no address is specified, the address will be
+# allocated dynamically (if possible), but the host-specific information
+# will still come from the host declaration.
+
+#host passacaglia {
+#  hardware ethernet 0:0:c0:5d:bd:95;
+#  filename "vmunix.passacaglia";
+#  server-name "toccata.example.com";
+#}
+
+# Fixed IP addresses can also be specified for hosts.   These addresses
+# should not also be listed as being available for dynamic assignment.
+# Hosts for which fixed IP addresses have been specified can boot using
+# BOOTP or DHCP.   Hosts for which no fixed address is specified can only
+# be booted with DHCP, unless there is an address range on the subnet
+# to which a BOOTP client is connected which has the dynamic-bootp flag
+# set.
+#host fantasia {
+#  hardware ethernet 08:00:07:26:c0:a5;
+#  fixed-address fantasia.example.com;
+#}
+
+# You can declare a class of clients and then do address allocation
+# based on that.   The example below shows a case where all clients
+# in a certain class get addresses on the 10.17.224/24 subnet, and all
+# other clients get addresses on the 10.0.29/24 subnet.
+
+#class "foo" {
+#  match if substring (option vendor-class-identifier, 0, 4) = "SUNW";
+#}
+
+#shared-network 224-29 {
+#  subnet 10.17.224.0 netmask 255.255.255.0 {
+#    option routers rtr-224.example.org;
+#  }
+#  subnet 10.0.29.0 netmask 255.255.255.0 {
+#    option routers rtr-29.example.org;
+#  }
+#  pool {
+#    allow members of "foo";
+#    range 10.17.224.10 10.17.224.250;
+#  }
+#  pool {
+#    deny members of "foo";
+#    range 10.0.29.10 10.0.29.230;
+#  }
+#}
+
+```

--- a/src/websites/book.md
+++ b/src/websites/book.md
@@ -46,6 +46,3 @@ Docs is clearly no longer our defacto documentation tool after lasting multiple 
 [mdBook](https://rust-lang.github.io/mdBook/) in our opinion is the more maintainable tool for documentation. It is very feature poor, however it renders to _static_ HTML, CSS, and Javascript. There is no "mdBook server" that will memory leak. There is just some service ([NGINX](https://nginx.org/) at the time of writing) that hosts unchanging content.
 
 The longevity of Book remains to be seen. Any challenges to it's reign should carefully consider the history of documentation in the labs in an effort to not repeat the same mistakes.
-
-
-


### PR DESCRIPTION
- Added and updated information on pages for hydra and tiamat
- Added page for TalDos
- Updated DHCP & DNS pages to point to TalDos
- Added DHCP configuration
- Updated IP allocations to reflect Talos and TalDos's new IPs