### PR TITLE
Add information about talks, firewall, DHCP, DNS, and add Tiamat to IP allocations

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,6 +9,7 @@
     - [Allocations](./infrastructure/network/ip_allocations.md)
     - [Topology](./infrastructure/network/topology.md)
     - [Switches](./infrastructure/network/switches.md)
+    - [VLANs](./infrastructure/network/vlans.md)
 
 - [Racks](./infrastructure/racks.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -17,6 +17,7 @@
     - [Elephant](./infrastructure/servers/elephant.md)
   	- [Eldwyn](./infrastructure/servers/eldwyn.md)
     - [Hydra](./infrastructure/servers/hydra.md)
+    - [Kasper](./infrastructure/servers/kasper.md)
     - [Talos](./infrastructure/servers/talos.md)
     - [TalDos](./infrastructure/servers/taldos.md)
     - [Tiamat](./infrastructure/servers/tiamat.md)
@@ -59,11 +60,11 @@
     - [Murmur (Mumble)](./services/murmur.md)
 
 - [Websites]()
-    - [cslabs]()
+    - [cslabs](./websites/cslabs.md)
     - [book](./websites/book.md)
     - [files]()
     - [random]()
-    - [talks]()
+    - [talks](./websites/talks.md)
 
 - [Mirror](./mirror/introduction.md)
     - [Hardware](./mirror/hardware.md)
@@ -73,4 +74,4 @@
 # Guides 
 
 - [Guides]() 
-    - [COSI Accounts](./guides/cosi_accounts.md)
+    - [COSI Accounts]()

--- a/src/infrastructure/network/ip_allocations.md
+++ b/src/infrastructure/network/ip_allocations.md
@@ -36,6 +36,7 @@ _updated: Sep 25, 2023_
 | 2 | [Ziltoid](../servers/ziltoid.md) |
 | 3 | [TalDos](../servers/taldos.md) |
 | 4 | [Talos](../servers/talos.md) |
+| 41 | [Tiamat](../servers/tiamat.md) |
 | 42 | [Hydra](../servers/hydra.md) |
 | 53 | [TalDos](../servers/taldos.md) |
 | 179 | [hbox](../servers/hbox.md) |
@@ -48,8 +49,6 @@ _updated: Sep 25, 2023_
 _TODO: reallocate the entire network_
 
 ## IPv6 Address Listing for 2605:6480:c051::/48 network
-
-|
 
 ### Subnet Allocations
 

--- a/src/infrastructure/network/ip_allocations.md
+++ b/src/infrastructure/network/ip_allocations.md
@@ -4,7 +4,7 @@ All links on this page should point at the underlying physical (or virtual) _inf
 
 ## IP Address Listing for 128.153.144.1/24 subnet
 
-_updated: Sep 25, 2023_
+_updated: December 15, 2023_
 
 | 128.153.144.# | Name |
 | :--- | :---
@@ -33,7 +33,7 @@ _updated: Sep 25, 2023_
 | 128.153.145.# | Name |
 | :--- | :---
 | 1 | OIT Gateway |
-| 2 | [Ziltoid](../servers/ziltoid.md) |
+| 2 | [Kasper](../servers/kasper.md) |
 | 3 | [TalDos](../servers/taldos.md) |
 | 4 | [Talos](../servers/talos.md) |
 | 41 | [Tiamat](../servers/tiamat.md) |

--- a/src/infrastructure/network/switches.md
+++ b/src/infrastructure/network/switches.md
@@ -2,33 +2,60 @@
 
 The purpose of this document is to provide more detailed descriptions of our managed network switches. 
 
-## F2
+## FHILL
 
-_updated: Jan 12th 2023_
+_updated: December 17th, 2023_
 
-F2 is currently our top level fiber networking switch. It is a Juniper QFX 3500 running `JUNOS 12.3X50-D30.2`. The management interface is assigned to `128.153.145.21`.
+FHILL is currently our top level fiber networking switch. It is a
+[Mikrotik CRS326-24S+2Q+RM](https://mikrotik.com/product/crs326_24s_2q_rm)
+running `RouterOS v7`. The management interface is assigned to `128.153.145.21`,
+and is currently only accessible by plugging in to one of the service ports.
+If in doubt, the Ethernet port labeled `MGMT/BOOT` should always be configured
+to allow access to the management interface.
 
 | Ports | Count |
 |-------------|-------|
-| SPF+ (10G)  | 48    |
-| QSPF+ (40G) | 4     |
+| SPF+ (10G)  | 24    |
+| QSPF+ (40G) | 2     |
 
-The switch is physically split into 6 groups of 8 SFP+ ports and 1 group of 4 QSPF+ ports. 
+The switch is physically split into 3 groups of 8 SFP+ ports and 1 group
+containing the 2 QSFP+ ports. It also has a 100M Ethernet port for management.
 
 ```
-| 0 | 2 | 4 | 6 |   | 8 | 10 | 12 | 14 |   | 16 | 18 | 20 | 22 |   |  Q0  |  Q2  |   | 24 | 26 | 28 | 30 |   | 32 | 34 | 36 | 38 |   | 40 | 42 | 44 | 46 |
-|---|---|---|---|---|---|----|----|----|---|----|----|----|----|---|------|------|---|----|----|----|----|---|----|----|----|----|---|----|----|----|----|
-| 1 | 3 | 5 | 7 |   | 9 | 11 | 13 | 15 |   | 17 | 19 | 21 | 23 |   |  Q1  |  Q3  |   | 25 | 27 | 29 | 31 |   | 33 | 35 | 37 | 39 |   | 41 | 43 | 45 | 47 |
+| 0 | 2 | 4 | 6 |   | 8 | 10 | 12 | 14 |   | 16 | 18 | 20 | 22 |   |  Q0  |   |      |
+|---|---|---|---|---|---|----|----|----|---|----|----|----|----|---|------|---|------|
+| 1 | 3 | 5 | 7 |   | 9 | 11 | 13 | 15 |   | 17 | 19 | 21 | 23 |   |  Q1  |   | MGMT |
 ```
 
-We've allocated (but have not configured) groups of ports to map to certain VLANs. Likewise, even number SFP+ ports are allocated for 10 gigabit while odd numbers are allocated to 1 gigabit. 
+We've configured groups of ports to map to certain [VLANs](../network/vlans.md).
 
-| Ports | VLANs    | Speed |
-|-------|----------|-------|
-| 0-7   | v2\_wan  | 10 G  |
-| 8-15  | v2\_wan  | 1 G   |
-| 16-23 | TBD      |       |
-| 24-39 | v3\_lan  | 10 G  |
-| 40-47 | v3\_lan  | 1 G   |
+| Ports | VID | Name       | Speed |
+|-------|-----|------------|-------|
+| 0-7   | 3   | cosi\_priv | 10 G  |
+| 8-15  | 2   | cosi\_pub  | 10 G  |
+| 16-23 | 1   | service    | 10 G  |
+| Q0-Q1 | 1   | service    | 40 G  |
+| MGMT  | 1   | service    | 100 M |
 
-On the back there are 2 RJ45 ports for management over IP and a RJ45 port for serial management using a cross over serial cable. The serial connection has a baud rate of `9600`.
+## FCOLO
+
+_updated: December 17th, 2023_
+
+FCOLO is our fiber network switch in COLO, which we are planning to use as our
+top level switch once we have moved some critical infrastructure there. It is a
+[Mikrotik CRS326-24S+2Q+RM](https://mikrotik.com/product/crs326_24s_2q_rm)
+running `RouterOS v7`. Its management interface is currently not accessible.
+
+| Ports | Count |
+|-------------|-------|
+| SPF+ (10G)  | 24    |
+| QSPF+ (40G) | 2     |
+
+The switch is physically split into 3 groups of 8 SFP+ ports and 1 group
+containing the 2 QSFP+ ports. It also has a 100M Ethernet port for management.
+
+```
+| 0 | 2 | 4 | 6 |   | 8 | 10 | 12 | 14 |   | 16 | 18 | 20 | 22 |   |  Q0  |   |      |
+|---|---|---|---|---|---|----|----|----|---|----|----|----|----|---|------|---|------|
+| 1 | 3 | 5 | 7 |   | 9 | 11 | 13 | 15 |   | 17 | 19 | 21 | 23 |   |  Q1  |   | MGMT |
+```

--- a/src/infrastructure/network/topology.md
+++ b/src/infrastructure/network/topology.md
@@ -197,7 +197,7 @@ graph {
 }
 ```
 
-- _"beef" is switch with a 40 gigabit uplink that has yet to been allocated by OIT. It will connect the Window's machines to OIT's lab vlan._
+- _"beef" is switch with a 40 gigabit uplink that has yet to be allocated by OIT. It will connect the Window's machines to OIT's lab vlan._
 
 ## VLANS
 
@@ -209,9 +209,9 @@ COSI has the following VLANs.
 
 | VLAN id | name   | description
 |---------|--------|-------------
-| 1       | unused | Many switches this is the default, therefor we don't use it 
+| 1       | unused | Many switches this is the default, therefore we don't use it 
 | 2       | v2\_cosi\_priv   | Our "default". This VLAN is behind the [firewall](../../services/firewall.md).
-| 3       | v3\_cosi\_public | VLAN with a direct connection to OIT. This is infront of the [firewall](../../services/firewall.md).
+| 3       | v3\_cosi\_public | VLAN with a direct connection to OIT. This is in front of the [firewall](../../services/firewall.md).
 | 4       | v4\_146 | VLAN for the 128.153.146.0/24 network. Currently this is unused and not well documented
 | 5       | v5\_phones | VLAN for Voice Over IP (VOIP) phones. Read [Asterisk](../../services/asterisk.md) for more information.
 | 6       | v6\_iot | VLAN for untrusted devices that require an internet connect. Think : Amazon Alexa |

--- a/src/infrastructure/network/topology.md
+++ b/src/infrastructure/network/topology.md
@@ -36,7 +36,7 @@ If you have trouble distinguishing colors, you can read the source code.
 
 ## Current Topology
 
-_updated: Mar 2nd 2023_
+_updated: December 17th, 2023_
 
 ```dot process
 /* COSI network topology
@@ -56,7 +56,7 @@ graph {
 	/* Nodes */
 	internet [shape=none,height=1,width=1,fixedsize=true,image="cloud.gif",label=""];
 	mirror [class="host"];
-	ziltoid [class="host"];
+	kasper [class="host"];
 
 	subgraph switches {
 		node [shape="record"]
@@ -64,7 +64,7 @@ graph {
 		jgw [class="clarkson"];
 		sc334 [class="clarkson",label="sc-334-c2960s"];
 	
-		f2 [class="agg"];
+		FHILL [class="agg"];
 	
 		m2 [class="managed"];
 		m3 [class="managed"];
@@ -80,7 +80,7 @@ graph {
 		cosi2 [class="unmanaged"];
 	}
 
-	talos [class="host"];
+	taldos [class="host"];
 	eldwyn [class="host"];
 	hydra [class="host"];
 	tiamat [class="host"];
@@ -96,19 +96,19 @@ graph {
 	internet -- jgw[dir=back,len=1,class="clarkson"];
 	jgw -- sc334 [class="clarkson"];
 	
-	sc334 -- f2 -- mirror [class="smf10",label="3"];
-	f2 -- ziltoid [dir=forward,class="smf10",label="3"];
-	f2 -- ziltoid [dir=back,class="smf10",label="2"];
-	f2 -- tiamat [class="smf10",label="2"];
+	sc334 -- FHILL -- mirror [class="smf10",label="3"];
+	FHILL -- kasper [dir=forward,class="smf10",label="3"];
+	FHILL -- kasper [dir=back,class="smf10",label="2"];
+	FHILL -- tiamat [class="smf10",label="2"];
 
-	f2 -- private  [label="2"];
-	private -- {itl1, itl2, itl3, itl4, talos, hydra, ziltoid};
+	FHILL -- private  [label="2"];
+	private -- {itl1, itl2, itl3, itl4, taldos, hydra, kasper};
 	{itl1, itl2, itl3, itl4} -- ITL;
 
-	f2 -- {cosi1, cosi2, m2} [label="2"];
+	FHILL -- {cosi1, cosi2, m2} [label="2"];
 	{cosi1, cosi2} -- COSI;
 
-	f2 -- m3 [label="2,5"];
+	FHILL -- m3 [label="2,5"];
 
 	m2 -- {prometheus, wifi};
 	m3 -- {eldwyn};
@@ -132,18 +132,16 @@ graph {
 	subgraph switches {
 		node [shape="record"]
 		jgw [class="clarkson"];
-		sc334 [class="clarkson",label="sc-334-c2960s"];
-		"beef*" [class="clarkson"];
 		
-		fcolo [class="agg"];
-		fhill [class="agg"];
+		FCOLO [class="agg"];
+		FHILL [class="agg"];
 		
-		mnet [class="managed"];
 		mrackl [class="managed"];
 		mrackr [class="managed"];
+		mnet [class="managed"];
 
 		wifi [class="unmanaged"];
-		shitch [class="unmanaged"];
+
 		itl1 [class="unmanaged"];
 		itl2 [class="unmanaged"];
 		itl3 [class="unmanaged"];
@@ -153,66 +151,35 @@ graph {
 	}
 
 	mirror [class="host",href="../../mirror/introduction.md"];
-	ziltoid [class="host",href="../servers/ziltoid.md"];
+	kasper [class="host",href="../servers/kasper.md"];
+	taldos [class="host",href="../servers/talos.html"];
 	hydra [class="host",href="../servers/hydra.html"];
 	bacon [class="host",href="../servers/bacon.html"];
 	tiamat [class="host",href="../servers/tiamat.html"];
-	eldwyn [class="host",href="../servers/eldwyn.html"];
-	"grand-dad" [class="host"];
-	ziltoid [class="host",href="../servers/ziltoid.html"];
-	talos [class="host",href="../servers/talos.html"];
+	TBD [class="host"];
 	elephant [class="host",href="../servers/elephant.html"];
 	prometheus [class="host"];
 	norm [class="host"];
 	"red-dwarf" [class="host"];
+
 	COSI [class="room"];
 	ITL [class="room"];
 	
 	/* Edges */
 	internet -- jgw [dir=back,class="clarkson"];
-	jgw -- {sc334, "beef*"} [class="clarkson"];
-	"beef*" -- ITL [class="room"];
-	fhill -- sc334 [class="smf10",label="3"];
-	fcolo -- jgw [class="smf10",label="3"];
+	FHILL -- FCOLO [class="smf10",label="2"];
+	FCOLO -- jgw [class="clarkson"];
 
-	fcolo -- fhill [class="smf10",label="2,4,5,6,7"];
-	fhill -- {mnet, hydra, bacon, tiamat} [class="smf10",label="2"];
-	fhill -- mrackl [label="2,5"];
-	fhill -- mrackr [label="2"];
+	FHILL -- {mrackl, mrackr, mnet, hydra, bacon, tiamat} [class="smf10",label="2"];
 	mnet -- {itl1, itl2, itl3, itl4, cosi1, cosi2, wifi};
 	mrackr -- {norm, "red-dwarf", prometheus} [label="2"];
-	mrackl -- "grand-dad" [label="2"];
-	mrackl -- eldwyn [label="2,5"];
+	mrackl -- TBD [label="2"];
 	{cosi1, cosi2} -- COSI [class="room"];
 	{itl1, itl2, itl3, itl4} -- ITL [class="room"];
-	shitch -- talos;
-	shitch -- ziltoid;
-	fcolo -- {mirror} [class="smf10",label="3"];
-	fcolo -- shitch [dir=forward,label="2"];
-	fcolo -- elephant [class="smf10",label="2"];
-	fcolo -- shitch [dir=back];
-	fcolo -- ziltoid [dir=forward,class="smf10",label="3"];
-	fcolo -- ziltoid [dir=back,class="smf10",label="2"];
+	FCOLO -- {mirror} [class="smf10",label="3"];
+	FCOLO -- {elephant, taldos} [class="smf10",label="2"];
+	FCOLO -- kasper [dir=forward,class="smf10",label="3"];
+	FCOLO -- kasper [dir=back,class="smf10",label="2"];
 	norm -- prometheus [class="e10g",label="direct 10G",fontcolor="blue"];
 }
 ```
-
-- _"beef" is switch with a 40 gigabit uplink that has yet to be allocated by OIT. It will connect the Window's machines to OIT's lab vlan._
-
-## VLANS
-
-_updated: Jan 15th 2023_
-
-> TODO: Make a separate page for VLANs w/ a short explanation and more detail.
-
-COSI has the following VLANs.
-
-| VLAN id | name   | description
-|---------|--------|-------------
-| 1       | unused | Many switches this is the default, therefore we don't use it 
-| 2       | v2\_cosi\_priv   | Our "default". This VLAN is behind the [firewall](../../services/firewall.md).
-| 3       | v3\_cosi\_public | VLAN with a direct connection to OIT. This is in front of the [firewall](../../services/firewall.md).
-| 4       | v4\_146 | VLAN for the 128.153.146.0/24 network. Currently this is unused and not well documented
-| 5       | v5\_phones | VLAN for Voice Over IP (VOIP) phones. Read [Asterisk](../../services/asterisk.md) for more information.
-| 6       | v6\_iot | VLAN for untrusted devices that require an internet connect. Think : Amazon Alexa |
-| 7       | v7\_cameras | A very poorly named VLAN for untrusted devices that do not require an internet connect. Consider the printer. Arguably, it seems the need for this VLAN is low.

--- a/src/infrastructure/network/vlans.md
+++ b/src/infrastructure/network/vlans.md
@@ -1,0 +1,54 @@
+# VLANs
+
+_updated: December 17th, 2023_
+
+COSI has allocated the following VLANs:
+
+| VID | Name       | Active? |
+|-----|------------|---------|
+| 1   | service    | yes     |
+| 2   | cosi\_priv | yes     |
+| 3   | cosi\_pub  | yes     |
+| 4   | 146        | no      |
+| 5   | phones     | no      |
+| 6   | iot        | no      |
+| 7   | cameras    | no      |
+
+
+## VLAN 1: `service`
+
+Since this is the default VID on many switches, it is never configured to allow
+access to the interent. Whenever possible, it should be used for unassigned
+interfaces and to provide access to management interfaces for our switches.
+
+## VLAN 2: `cosi_priv`
+
+This VLAN is our "default", and is behind our
+[firewall](../../services/firewall.md). Any personal computer, or any server
+that does not need direct from the Internet should be here.
+
+## VLAN 3: `cosi_pub`
+
+This VLAN has a direct connection to OIT, and is not protected by the 
+[firewall](../../services/firewall.md). Only servers that need direct, 
+unfiltered access to the Internet (ex. [Mirror](../../mirror/introduction.md))
+should be on this VLAN.
+
+## VLAN 4: `146`
+
+This VLAN was used for the 128.153.146.0/24 subnet, but is not currently active.
+
+## VLAN 5: `phones`
+
+This VLAN was used for our VOIP phones.
+See [Asterisk](../../services/asterisk.md) for more information.
+
+## VLAN 6: `iot`
+
+For untrusted devices that require an internet connection
+(ex. smart home devices). It is currently unused.
+
+## VLAN 7: `cameras`
+
+This VLAN was used for untrusted devices that do NOT require an internet
+connection. It is currently unused.

--- a/src/infrastructure/network/vlans.md
+++ b/src/infrastructure/network/vlans.md
@@ -18,7 +18,7 @@ COSI has allocated the following VLANs:
 ## VLAN 1: `service`
 
 Since this is the default VID on many switches, it is never configured to allow
-access to the interent. Whenever possible, it should be used for unassigned
+access to the internet. Whenever possible, it should be used for unassigned
 interfaces and to provide access to management interfaces for our switches.
 
 ## VLAN 2: `cosi_priv`

--- a/src/infrastructure/servers/kasper.md
+++ b/src/infrastructure/servers/kasper.md
@@ -1,0 +1,37 @@
+# Kasper
+
+_updated: December 15th, 2023_
+
+Kasper is our current firewall and the successor to [Ziltoid](ziltoid.md).
+It functions as a filtered bridge between our public and private VLANs.
+
+| | |
+| :--- | :--- |
+| Location | [Server Room - Network 1](../racks.md#network-1)
+| IP Addresses | 128.153.145.2
+| Deployed | true
+
+## Hardware
+
+| | |
+| :--- | :--- |
+| CPU | Intel(R) Xeon(R) CPU E5-2620 @ 2.00GHz
+| RAM | 8 GB
+| STORAGE | 2x 300 GB 15K SAS HDDs
+| CONNECTIVITY | 2x 10 Gigabit SFP+ NICs
+
+## Operating System
+
+| | |
+| :--- | :--- |
+| OS | GNU/Linux
+| Distro | Ubuntu 22.04
+| Last updated | Dec. 14th, 2023
+| End of life | April 2027
+| Enrolled in COSI auth | false
+| NFS Mount | false
+
+## Services
+
+- [Firewall](../../services/firewall.md)
+

--- a/src/infrastructure/servers/tiamat.md
+++ b/src/infrastructure/servers/tiamat.md
@@ -46,3 +46,8 @@ Docker host
 
 ## Notes
 
+Projects to be hosted are stored in the directory `/docker`. The quickest way to host a project on Tiamat is to clone its repository to this directory. You can manage containers individually with Docker or use `run.sh` to rebuild all projects.
+
+Incoming connections are forwarded to their respective containers using [NGINX Proxy Manager](https://nginxproxymanager.com/), which also handles SSL termination and certificates for each project.
+
+It is recommended to add the line `restart: unless-stopped` to your project's `docker-compose.yml` so that it is automatically restarted when Tiamat reboots.

--- a/src/infrastructure/servers/ziltoid.md
+++ b/src/infrastructure/servers/ziltoid.md
@@ -1,14 +1,14 @@
 # Ziltoid
 
-_updated: Jan 16th 2023_
+_updated: December 15th, 2023_
 
-Ziltoid acts as our firewall.
+Ziltoid was our firewall up until Fall 2023. It has since been superseded by [Kasper](kasper.md).
 
 | | |
 | :--- | :--- |
-| Location | [Server Room - Network 3](../racks.md#network-3)
-| IP Addresses | 128.153.145.2 , 2605:6480:c051:2::1
-| Deployed | true
+| Location | N/A
+| IP Addresses | N/A
+| Deployed | false
 
 ## Hardware
 
@@ -32,5 +32,6 @@ Ziltoid acts as our firewall.
 
 ## Services
 
-- [Firewall](../../services/firewall.md)
+## Notes
 
+Ziltoid was taken out of service in Fall 2023 after it crashed and was temporarily unable to boot due to a memory failure.

--- a/src/infrastructure/vms.md
+++ b/src/infrastructure/vms.md
@@ -31,7 +31,9 @@ _updated: Sept 18th 2022_
 
 ## atlas
 
-_updated: Sept 18th 2022_
+> deprecated: All DNS is handled by [TalDos](./servers/taldos.md).
+
+_updated: December 15th, 2023_
 
 Atlas is our secondary DNS server.
 

--- a/src/services/dhcp.md
+++ b/src/services/dhcp.md
@@ -1,15 +1,15 @@
 # DHCP
 
-_updated: Sept 30th 2022_
+_updated: December 1st, 2023_
 
 Since COSI has it's own network we also run a [DHCP](https://en.wikipedia.org/wiki/Dynamic_Host_Configuration_Protocol) server to manage ip allocations. DHCP is an important service because it allows people temporiliy using our network to avoid setting a static IP address. However, since DHCP servers lease IP address based on client's MAC addresses we can also use our server to easily manage the IPs of other clients on our network. For example, we can manage the ITL machines by manually mapping their MAC addresses to IPs and we never have to worry about setting a static IP on each machine.
 
 ## isc-dhcp-server
 
-The Internet Systems Consortium's implementation of a DHCP server is good 
-enough. We have a single dhcp server running on 
-[TalDos](../infrastructure/servers/taldos.md). In the past we had a fallback
-server running in a VM. This no longer exists.
+We have a single dhcp server running on [TalDos](../infrastructure/servers/taldos.md).
+In the past we had a fallback server running in a VM. This no longer exists.
+We currently use Internet Systems Consortium's implementation of a DHCP server, which
+has reached its end-of-life. We are currently working on testing a replacement.
 
 ## DHCP information
 
@@ -41,54 +41,11 @@ ddns-update-style none;
 # network, the authoritative directive should be uncommented.
 authoritative;
 
-# Use this to send dhcp log messages to a different log file (you also
-# have to hack syslog.conf to complete the redirection).
-# log-facility local7;
-
-# No service will be given on this subnet, but declaring it helps the 
-# DHCP server to understand the network topology.
-
-# subnet 10.152.187.0 netmask 255.255.255.0 {
-# }
-
-# This is a very basic subnet declaration.
-
 subnet 128.153.144.0 netmask 255.255.254.0 {
   range 128.153.144.100 128.153.144.254;
   option routers 128.153.144.1;
   option ntp-servers 128.153.2.253, 128.153.5.253;
 }
-
-# This declaration allows BOOTP clients to get dynamic addresses,
-# which we don't really recommend.
-
-#subnet 10.254.239.32 netmask 255.255.255.224 {
-#  range dynamic-bootp 10.254.239.40 10.254.239.60;
-#  option broadcast-address 10.254.239.31;
-#  option routers rtr-239-32-1.example.org;
-#}
-
-# A slightly different configuration for an internal subnet.
-#subnet 10.5.5.0 netmask 255.255.255.224 {
-#  range 10.5.5.26 10.5.5.30;
-#  option domain-name-servers ns1.internal.example.org;
-#  option domain-name "internal.example.org";
-#  option routers 10.5.5.1;
-#  option broadcast-address 10.5.5.31;
-#  default-lease-time 600;
-#  max-lease-time 7200;
-#}
-
-# Hosts which require special configuration options can be listed in
-# host statements. If no address is specified, the address will be
-# allocated dynamically (if possible), but the host-specific information
-# will still come from the host declaration.
-
-#host passacaglia {
-#  hardware ethernet 0:0:c0:5d:bd:95;
-#  filename "vmunix.passacaglia";
-#  server-name "toccata.example.com";
-#}
 
 # Fixed IP addresses can also be specified for hosts.   These addresses
 # should not also be listed as being available for dynamic assignment.
@@ -110,22 +67,8 @@ subnet 128.153.144.0 netmask 255.255.254.0 {
 #class "foo" {
 #  match if substring (option vendor-class-identifier, 0, 4) = "SUNW";
 #}
-
-#shared-network 224-29 {
-#  subnet 10.17.224.0 netmask 255.255.255.0 {
-#    option routers rtr-224.example.org;
-#  }
-#  subnet 10.0.29.0 netmask 255.255.255.0 {
-#    option routers rtr-29.example.org;
-#  }
-#  pool {
-#    allow members of "foo";
-#    range 10.17.224.10 10.17.224.250;
-#  }
-#  pool {
-#    deny members of "foo";
-#    range 10.0.29.10 10.0.29.230;
-#  }
-#}
-
 ```
+
+## Notes
+
+As of 12/01/23, the default DNS servers are 1.1.1.1 and 1.0.0.1 (Cloudflare) due to issues with Unbound

--- a/src/services/firewall.md
+++ b/src/services/firewall.md
@@ -1,8 +1,11 @@
 # Firewall
 
-_updated: December 1st, 2023_
+_updated: December 15st, 2023_
 
-Since COSI has its own network, we need to run our own Firewall. Our firewall is very simple; blocking all traffic except to hosts we create holes for. Our firewall runs on [Ziltoid](../infrastructure/servers/ziltoid.md).
+Since COSI has its own network, we need to run our own firewall. 
+Our firewall is a filtered bridge between our public and private VLANS; blocking 
+all traffic except to hosts we create holes for. Our firewall currently runs on
+[Kasper](../infrastructure/servers/kasper.md).
 
 Firewall rules are kept in a private repository, which will not be linked here.
 
@@ -15,4 +18,6 @@ Some notes:
 ## nftables
 
 Our firewall is configured with nftables (the successor to iptables). 
-Although the firewall repository has tools for some common tasks, it is a good idea to get familiar with how [nftables](https://wiki.nftables.org/) works so that you are able to make rules and fix problems should they arise.
+Although the firewall repository has tools for some common tasks, it is a good
+idea to get familiar with how [nftables](https://wiki.nftables.org/) works so
+that you are able to make rules and fix problems should they arise.

--- a/src/services/firewall.md
+++ b/src/services/firewall.md
@@ -1,14 +1,18 @@
 # Firewall
 
-_updated: Oct 16th 2022_
+_updated: December 1st, 2023_
 
-Since COSI has it's own network we need to run our own Firewall. Our firewall is very simple: block all traffic except to ports we poke holes for. Our firewall current runs on [Ziltoid](../infrastructure/servers/ziltoid.md).
+Since COSI has its own network, we need to run our own Firewall. Our firewall is very simple; blocking all traffic except to hosts we create holes for. Our firewall runs on [Ziltoid](../infrastructure/servers/ziltoid.md).
+
+Firewall rules are kept in a private repository, which will not be linked here.
 
 Some notes:
 - Mirror should should not be behind the firewall, but the firewall should be configured that if Mirror accidentally lands behind the firewall nothing should break.
 - Try your best to not open insecure ports. For example, opening ssh to a lab machine is dangerous because csguest is typically `sudo`.
-- Rules should periodically be audited
+- SSH should be configured off of the default port (22) to reduce the risk of automated attacks.
+- Rules should periodically be audited. If a service is inactive, its firewall holes should be closed until it is brought up again.
 
-## iptables
+## nftables
 
-TODO
+Our firewall is configured with nftables (the successor to iptables). 
+Although the firewall repository has tools for some common tasks, it is a good idea to get familiar with how [nftables](https://wiki.nftables.org/) works so that you are able to make rules and fix problems should they arise.

--- a/src/services/recursive_dns.md
+++ b/src/services/recursive_dns.md
@@ -1,6 +1,6 @@
 # Recursive DNS
 
-_updated: Sept 4th 2022_
+_updated: December 1st, 2023_
 
 The lab runs it's own caching DNS server located at `128.153.145.53`. If you need to set a static IP in COSI use `128.153.145.53` as the DNS or "Name Server" entry.
 
@@ -34,14 +34,14 @@ dns2: 8.8.4.4
 
 We currently use [Unbound](https://en.wikipedia.org/wiki/Unbound_(DNS_server)) for DNS. If possible, other clients should do their best to have their own DNS caches to further decrease latency when repeatedly accessing the same sites. 
 
-Unbound is currently running on a VM named: [unbound](../infrastructure/vms.md#unbound). There are plans to migrate to a Docker container.
+Unbound is currently running on [TalDos](../infrastructure/servers/taldos.md).
 
 ### Configuration
 ```
 server:
-    # Bind to everything
-    interface: 0.0.0.0
-    interface: 0::
+    # Bind
+    interface: 128.153.145.53
+    interface: 2605:6480:c051:53::1
 
     ## Allow the whole clarkson network
     # access-control: 128.153.0.0/16 allow
@@ -72,5 +72,6 @@ stub-zone:
 forward-zone:
     name: "."
     forward-addr: 128.153.0.254
-    forward-addr: 128.153.5.254
+    # forward-addr: 128.153.5.254
+    forward-addr: 1.1.1.1
 ```

--- a/src/the_cosi_book.md
+++ b/src/the_cosi_book.md
@@ -1,6 +1,4 @@
 # The COSI Book
 
-The COSI Book serves as the preferred location for the creation and migration of documentation regarding the labs and it's infrastructure. 
-## Sections
-
-
+The COSI Book is the preferred location for the creation and migration of
+documentation regarding the labs and our infrastructure. 

--- a/src/websites/cslabs.md
+++ b/src/websites/cslabs.md
@@ -1,0 +1,8 @@
+# CSlabs
+
+_updated: December 6, 2023_
+
+CSlabs (<https://cslabs.clarkson.edu>) is the homepage for Clarkson University's Applied Computer Science Labs.
+It is currently hosted as a [docker](https://www.docker.com/) container on [Tiamat](../infrastructure/servers/tiamat.md). Its source code is available at <https://github.com/COSI-Lab/cslabs>.
+
+The CSlabs website contains general information about the applied CS labs, as well as pages specific to COSI, the ITL, and the VR lab. It also contains links to resources and services hosted by COSI, as well as a contact page for the CS department and the labs.

--- a/src/websites/talks.md
+++ b/src/websites/talks.md
@@ -1,1 +1,13 @@
 # Talks
+
+_updated: December 1st, 2023_
+
+Talks is a web app that allows lab members to schedule topics for our weekly meetings. It can be accessed at <https://talks.cosi.clarkson.edu>.
+
+Talks is currently hosted as a [docker](https://www.docker.com/) container on [Tiamat](../infrastructure/servers/tiamat.md).
+
+[go-talks](https://github.com/COSI-Lab/go-talks) is the latest of several rewrites of Talks. Its source code is located on the [COSI-Lab](https://github.com/COSI-Lab/) organization on github.
+
+## Notes
+
+Adding talks from outside the labs requires a password. If you still get the password prompt while in the labs, make sure you are connected to the right network (connections from the rest of the university are treated as external).


### PR DESCRIPTION
- Talks page is no longer empty
- A bit more information about the firewall and nftables
- DHCP server is now EOL :(
- Trimmed unnecessary comments from DHCP server config
- Tiamat is now on the 145 subnet listing
- Updated unbound info and config